### PR TITLE
javax.portlet.name is incorrect

### DIFF
--- a/gradle/blade.configurationaction/src/main/java/com/liferay/blade/samples/configurationaction/MessageDisplayConfigurationAction.java
+++ b/gradle/blade.configurationaction/src/main/java/com/liferay/blade/samples/configurationaction/MessageDisplayConfigurationAction.java
@@ -44,7 +44,7 @@ import org.osgi.service.component.annotations.Modified;
 	configurationPid = "com.liferay.blade.samples.configurationaction.MessageDisplayConfiguration",
 	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
 	property = {
-		"javax.portlet.name=blade_configurationaction_portlet_BladeMessagePortlet"
+		"javax.portlet.name=com_liferay_blade_samples_configurationaction_BladeMessagePortlet"
 	},
 	service = ConfigurationAction.class
 )


### PR DESCRIPTION
With this current javax.portlet.name, the contents of view.jsp is not displayed. Fixed the name to be view.jsp properly displayed.