### PR TITLE
Change version of the liferay-npm-bundler from 1.2.2 to 1.6.0

### DIFF
--- a/gradle/apps/npm/react-npm-portlet/package.json
+++ b/gradle/apps/npm/react-npm-portlet/package.json
@@ -7,10 +7,10 @@
 	"devDependencies": {
 		"babel-cli": "6.26.0",
 		"babel-preset-es2015": "6.24.1",
-		"babel-preset-liferay-project": "1.2.2",
+		"babel-preset-liferay-project": "1.6.0",
 		"babel-preset-react": "6.24.1",
-		"liferay-npm-bundler": "1.2.2",
-		"liferay-npm-bundler-preset-react": "1.2.2"
+		"liferay-npm-bundler": "1.6.0",
+		"liferay-npm-bundler-preset-react": "1.6.0"
 	},
 	"main": "lib/index.es.js",
 	"name": "react-npm-portlet",

--- a/liferay-workspace/apps/npm/react-npm-portlet/package.json
+++ b/liferay-workspace/apps/npm/react-npm-portlet/package.json
@@ -7,10 +7,10 @@
 	"devDependencies": {
 		"babel-cli": "6.26.0",
 		"babel-preset-es2015": "6.24.1",
-		"babel-preset-liferay-project": "1.2.2",
+		"babel-preset-liferay-project": "1.6.0",
 		"babel-preset-react": "6.24.1",
-		"liferay-npm-bundler": "1.2.2",
-		"liferay-npm-bundler-preset-react": "1.2.2"
+		"liferay-npm-bundler": "1.6.0",
+		"liferay-npm-bundler-preset-react": "1.6.0"
 	},
 	"main": "lib/index.es.js",
 	"name": "react-npm-portlet",


### PR DESCRIPTION
I changed version because old version I'm getting this build error.

```
> Task :apps:npm:react-npm-portlet:npmRunBuild

> react-npm-portlet@1.0.0 build /private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet
> babel --source-maps -d build/resources/main/META-INF/resources src/main/resources/META-INF/resources && liferay-npm-bundler

TypeError: src/main/resources/META-INF/resources/lib/index.es.js: Cannot read property 'info' of undefined
    at Object.ExpressionStatement (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-plugin-name-amd-modules/lib/index.js:54:16)
    at NodePath._call (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-traverse/lib/path/context.js:76:18)
    at NodePath.call (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-traverse/lib/path/context.js:48:17)
    at NodePath.visit (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-traverse/lib/path/context.js:105:12)
    at TraversalContext.visitQueue (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-traverse/lib/context.js:150:16)
    at TraversalContext.visitMultiple (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-traverse/lib/context.js:103:17)
    at TraversalContext.visit (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-traverse/lib/context.js:190:19)
    at Function.traverse.node (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-traverse/lib/index.js:114:17)
    at traverse (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-traverse/lib/index.js:79:12)
    at NodePath.traverse (/private/tmp/liferay-blade-samples/liferay-workspace/apps/npm/react-npm-portlet/node_modules/babel-traverse/lib/path/index.js:144:25)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! react-npm-portlet@1.0.0 build: `babel --source-maps -d build/resources/main/META-INF/resources src/main/resources/META-INF/resources && liferay-npm-bundler`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-npm-portlet@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/amusarra/.npm/_logs/2018-03-15T13_53_32_823Z-debug.log


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':apps:npm:react-npm-portlet:npmRunBuild'.
> Process 'command '/private/tmp/liferay-blade-samples/liferay-workspace/build/node/bin/node'' finished with non-zero exit value 1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 18s
```