### PR TITLE
replaced dead link

### DIFF
--- a/liferay-workspace/extensions/control-menu-entry/src/main/java/com/liferay/blade/samples/controlmenuentry/BladeProductNavigationControlMenuEntry.java
+++ b/liferay-workspace/extensions/control-menu-entry/src/main/java/com/liferay/blade/samples/controlmenuentry/BladeProductNavigationControlMenuEntry.java
@@ -49,10 +49,10 @@ public class BladeProductNavigationControlMenuEntry
 	implements ProductNavigationControlMenuEntry {
 
 	/**
-	 * Returns the icon to display in the Control Menu. By default, Lexicon
-	 * icons are expected to be returned. To view all the Lexicon icons
+	 * Returns the icon to display in the Control Menu. By default, Clay
+	 * icons are expected to be returned. To view all the Clay icons
 	 * available, see
-	 * <a href="http://liferay.github.io/lexicon/content/icons-lexicon/">http://liferay.github.io/lexicon/content/icons-lexicon/</a>.
+	 * <a href="http://v2.clayui.com/docs/components/icons.html/">http://v2.clayui.com/docs/components/icons.html</a>.
 	 *
 	 * @param  httpServletRequest the request
 	 * @return the icon to display in the Control Menu


### PR DESCRIPTION
Lexicon doesn't have icons. Clay has them.